### PR TITLE
fixed resource update so that resources with foreign keys can be updated

### DIFF
--- a/chain/core/api.py
+++ b/chain/core/api.py
@@ -518,7 +518,8 @@ class Resource(object):
         in the format given by this resource's schema'''
         for k, v in data.iteritems():
             if k in self.model_fields:
-                setattr(self._obj, k, v)
+                sanitized_value = type(self).sanitize_field_value(k, v)
+                setattr(self._obj, k, sanitized_value)
             elif k in self.stub_fields:
                 setattr(self._obj, k,
                         self.stub_object_finding(self._obj, k, v))


### PR DESCRIPTION
fixes error associated with #47.

NOTE:  this shouldn't close issue #47 (it is merely a temporary fix) , because we still need to discuss changing how ForeignKeys are represented in the schema.  Currently, they are represented as URL strings which are siblings of other attributes, but this isn't very HAL-like.  We might put them in _links instead.